### PR TITLE
Remove preventDefault()

### DIFF
--- a/dist/heatmapper.js
+++ b/dist/heatmapper.js
@@ -80,7 +80,6 @@
 	  }, {
 	    key: 'placeClick',
 	    value: function placeClick(event) {
-	      event.preventDefault();
 	      var click = {
 	        path: cssPath(event.target),
 	        position: {

--- a/examples/assets/js/heatmapper.js
+++ b/examples/assets/js/heatmapper.js
@@ -80,7 +80,6 @@
 	  }, {
 	    key: 'placeClick',
 	    value: function placeClick(event) {
-	      event.preventDefault();
 	      var click = {
 	        path: cssPath(event.target),
 	        position: {

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,6 @@ class Heatmapper {
   }
 
   placeClick(event) {
-    event.preventDefault()
     const click = {
       path: cssPath(event.target),
       position: {


### PR DESCRIPTION
I've removed the `preventDefault()` call in the click handler on the document body as it prevented elements like `<a/>`s from functioning
