### PR TITLE
Enabled click tracking on elements with stopPropagation

### DIFF
--- a/dist/heatmapper.js
+++ b/dist/heatmapper.js
@@ -105,6 +105,13 @@
 	      document.addEventListener('click', function (event) {
 	        return _this.placeClick(event);
 	      });
+	      // Override stopPropagation
+	      var oldStopPropagation = Event.prototype.stopPropagation;
+	      var clickTracker = this;
+	      Event.prototype.stopPropagation = function () {
+	        clickTracker.placeClick(this);
+	        oldStopPropagation.call(this);
+	      };
 	    }
 	  }, {
 	    key: 'placeClick',

--- a/examples/assets/js/heatmapper.js
+++ b/examples/assets/js/heatmapper.js
@@ -105,6 +105,13 @@
 	      document.addEventListener('click', function (event) {
 	        return _this.placeClick(event);
 	      });
+	      // Override stopPropagation
+	      var oldStopPropagation = Event.prototype.stopPropagation;
+	      var clickTracker = this;
+	      Event.prototype.stopPropagation = function () {
+	        clickTracker.placeClick(this);
+	        oldStopPropagation.call(this);
+	      };
 	    }
 	  }, {
 	    key: 'placeClick',

--- a/src/ClickTracker.js
+++ b/src/ClickTracker.js
@@ -11,6 +11,13 @@ export default class ClickTracker {
 
   bindEvents() {
     document.addEventListener('click', (event) => this.placeClick(event))
+    // Override stopPropagation
+    const oldStopPropagation = Event.prototype.stopPropagation
+    const clickTracker = this
+    Event.prototype.stopPropagation = function() {
+      clickTracker.placeClick(this)
+      oldStopPropagation.call(this)
+    }
   }
 
   placeClick(event) {


### PR DESCRIPTION
Have overridden stopPropagation to allow tracking when events don't reach the document root.
